### PR TITLE
Utilize central directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,18 +33,21 @@
   "devDependencies": {
     "@biomejs/biome": "=1.9.4",
     "@types/chai": "^5.0.1",
+    "@types/debug": "^4",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.9.3",
     "chai": "^5.1.2",
     "del-cli": "^6.0.0",
     "file-type": "^19.6.0",
     "mocha": "^10.8.2",
-    "strtok3": "^9.0.1",
+    "strtok3": "^10.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2"
   },
   "dependencies": {
+    "debug": "^4.3.7",
     "fflate": "^0.8.2",
+    "link": "^2.1.1",
     "token-types": "^6.0.0"
   },
   "repository": {

--- a/test/test.ts
+++ b/test/test.ts
@@ -16,7 +16,6 @@ async function extractFileFromFixture(fixture: string, filename: string): Promis
   try {
     let fileData: Uint8Array | undefined;
     await zipHandler.unzip(zipFile => {
-      console.log(`filename="${zipFile.filename}", compressedMethod=${zipFile.compressedMethod}, dataDescriptor=${zipFile.dataDescriptor}`);
       const match = zipFile.filename === filename;
       return {
         handler: match ? async _fileData => {
@@ -33,17 +32,18 @@ async function extractFileFromFixture(fixture: string, filename: string): Promis
 
 describe('Different ZIP encode options', () => {
 
+  it("inflate a ZIP file with the \"data descriptor\" flag disabled", async () => {
+    const fileData = await extractFileFromFixture('fixture.docx', '[Content_Types].xml');
+    assert.isDefined(fileData);
+    assertFileIsXml(fileData);
+  });
+
   it("inflate a ZIP file with the \"data descriptor\" flag set", async () => {
     const fileData = await extractFileFromFixture('file_example_XLSX_10.xlsx', '[Content_Types].xml');
     assert.isDefined(fileData);
     assertFileIsXml(fileData);
   });
 
-  it("inflate a ZIP file with the \"data descriptor\" flag disabled", async () => {
-    const fileData = await extractFileFromFixture('fixture.docx', '[Content_Types].xml');
-    assert.isDefined(fileData);
-    assertFileIsXml(fileData);
-  });
 
   it("extract uncompressed data", async () => {
     const fileData = await extractFileFromFixture('fixture.odp', 'mimetype');

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,14 +219,17 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:=1.9.4"
     "@types/chai": "npm:^5.0.1"
+    "@types/debug": "npm:^4"
     "@types/mocha": "npm:^10.0.10"
     "@types/node": "npm:^22.9.3"
     chai: "npm:^5.1.2"
+    debug: "npm:^4.3.7"
     del-cli: "npm:^6.0.0"
     fflate: "npm:^0.8.2"
     file-type: "npm:^19.6.0"
+    link: "npm:^2.1.1"
     mocha: "npm:^10.8.2"
-    strtok3: "npm:^9.0.1"
+    strtok3: "npm:^10.0.0"
     token-types: "npm:^6.0.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.7.2"
@@ -277,6 +280,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/debug@npm:^4":
+  version: 4.1.12
+  resolution: "@types/debug@npm:4.1.12"
+  dependencies:
+    "@types/ms": "npm:*"
+  checksum: 10c0/5dcd465edbb5a7f226e9a5efd1f399c6172407ef5840686b73e3608ce135eeca54ae8037dcd9f16bdb2768ac74925b820a8b9ecc588a58ca09eca6acabe33e2f
+  languageName: node
+  linkType: hard
+
 "@types/deep-eql@npm:*":
   version: 4.0.2
   resolution: "@types/deep-eql@npm:4.0.2"
@@ -288,6 +300,13 @@ __metadata:
   version: 10.0.10
   resolution: "@types/mocha@npm:10.0.10"
   checksum: 10c0/d2b8c48138cde6923493e42b38e839695eb42edd04629abe480a8f34c0e3f50dd82a55832c2e8d2b6e6f9e4deb492d7d733e600fbbdd5a0ceccbcfc6844ff9d5
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 0.7.34
+  resolution: "@types/ms@npm:0.7.34"
+  checksum: 10c0/ac80bd90012116ceb2d188fde62d96830ca847823e8ca71255616bc73991aa7d9f057b8bfab79e8ee44ffefb031ddd1bcce63ea82f9e66f7c31ec02d2d823ccc
   languageName: node
   linkType: hard
 
@@ -586,7 +605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.4, debug@npm:^4.3.5":
+"debug@npm:4, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
   dependencies:
@@ -1147,6 +1166,15 @@ __metadata:
   version: 1.1.0
   resolution: "jsbn@npm:1.1.0"
   checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
+  languageName: node
+  linkType: hard
+
+"link@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "link@npm:2.1.1"
+  bin:
+    link: dist/cli.js
+  checksum: 10c0/2ab956715e77c4fb9d78e16172301b59e2c03611feae4df33f50a70351445da050bea4010c682a0e187a09b5f2ee4462bab842153c2767a3b018de00b0e8282a
   languageName: node
   linkType: hard
 
@@ -1752,6 +1780,16 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
+  languageName: node
+  linkType: hard
+
+"strtok3@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "strtok3@npm:10.0.0"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+    peek-readable: "npm:^5.3.1"
+  checksum: 10c0/a9b3b37b4b65766bba8448098895ee1e175e1f592833aa41852ca745aa35a9de01a2da23ff929d2ee4eb55d3e14f59073ff3d1105fde789ebfb4a2f09e8642df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
If present, utilize the central directory and avoid scanning byte for byte.

Ref https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT